### PR TITLE
 Fix compilation issue with set and namespaces

### DIFF
--- a/src/ofxJoystick.h
+++ b/src/ofxJoystick.h
@@ -4,57 +4,58 @@
 
 #include "GLFW/glfw3.h"
 
+using namespace std;
 
 class ofxJoystick {
 private:
-  bool isConnect_;
+	bool isConnect_;
 
-  int    id_;
-  string name_;
+	int id_;
+	string name_;
 
-  int buttonNum_;
-  int axisNum_;
-  
-  set<int> pressed_;
-  set<int> pushing_;
-  set<int> release_;
-  
-  vector<float> axis_;
-  
-  void updateState();
-  void updateAxis();
-  void updateButton();
-  
-  void update(ofEventArgs &args);
+	int buttonNum_;
+	int axisNum_;
+
+	set<int> pressed_;
+	set<int> pushing_;
+	set<int> release_;
+
+	vector<float> axis_;
+
+	void updateState();
+	void updateAxis();
+	void updateButton();
+
+	void update(ofEventArgs & args);
 
 public:
-  ofxJoystick() = default;
-  ~ofxJoystick();
-  
-  // JoyId : usually give GLFW_SOYSTICK_1
-  // when you connect only one Gamepad
-  void setup(int JoyId);
+	ofxJoystick() = default;
+	~ofxJoystick();
 
-  // if connected return true
-  // disconnected return false
-  bool isConnect() const;
+	// JoyId : usually give GLFW_SOYSTICK_1
+	// when you connect only one Gamepad
+	void setup(int JoyId);
 
-  int getId() const;
-  
-  // return your Gamepad name
-  const string& getName() const;
+	// if connected return true
+	// disconnected return false
+	bool isConnect() const;
 
-  // return number of Button and Axis
-  int getButtonNum() const;
-  int getAxisNum() const;
-  
-  // return axis, if disconnected return 0
-  float getAxis(int num) const;
-  
-  // button func
-  bool isPressed(int button) const;
-  bool isPushing(int button) const;
-  bool isRelease(int button) const;
-  
-  bool anyButton() const;
+	int getId() const;
+
+	// return your Gamepad name
+	const string & getName() const;
+
+	// return number of Button and Axis
+	int getButtonNum() const;
+	int getAxisNum() const;
+
+	// return axis, if disconnected return 0
+	float getAxis(int num) const;
+
+	// button func
+	bool isPressed(int button) const;
+	bool isPushing(int button) const;
+	bool isRelease(int button) const;
+
+	bool anyButton() const;
 };


### PR DESCRIPTION
Over the years the of code base changed the namespaces , and thus not letting compile this tool.

Just added one line to make it work and hopefully doesn't break it for others.
Im on linux and my clang-format did its thing , if you don't like it I can make another PR without the changed formatting .

p.s : Thanks for this tool ! , I couldn't get any other addon to let me use a gamepad